### PR TITLE
Bring the app to front before showing the Preferences window

### DIFF
--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -137,6 +137,7 @@
 {
     self.preferencesWindow = [[STPreferencesWindowController alloc] init];
     [self.preferencesWindow.window setLevel:NSFloatingWindowLevel];
+    [NSApp activateIgnoringOtherApps:YES];
     [self.preferencesWindow showWindow:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(preferencesWillClose:)


### PR DESCRIPTION
Hey Jerry,
Thanks for the app!
The Preferences pane used to be behind the top window when shown, so I've added [NSApp activateIgnoringOtherApps:YES] to ensure the app is activated, as suggested for Status Bar apps.
