### PR TITLE
Signing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ make debug
 
 It will automaticly download syncthing amd64 binary and add it to the Application Bundle.
 
+For release builds signing the application build and creating an distributable DMG:
+
+```
+SYNCTHING_APP_CODE_SIGN_IDENTITY="Mac Developer: foo@bar.com (XB59MXU8EC)" make release
+```
+
 # Goal
 
 The goal of this project is to keep the Native Mac OS X Syncthing tray as simple as possible. No graphs, no advanced configuration

--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -603,7 +603,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "";
 				DEVELOPMENT_TEAM = "";

--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -366,7 +366,7 @@
 				};
 			};
 			buildConfigurationList = C4A4155B1D0D579D00DC6018 /* Build configuration list for PBXProject "syncthing" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -416,7 +416,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SOURCE_ROOT}/syncthing/Scripts/syncthing-resource.sh\n${SOURCE_ROOT}/syncthing/Scripts/syncthing-inotify-resource.sh\n${SOURCE_ROOT}/syncthing/Scripts/create-dmg.sh";
+			shellScript = "${SOURCE_ROOT}/syncthing/Scripts/syncthing-resource.sh\n${SOURCE_ROOT}/syncthing/Scripts/syncthing-inotify-resource.sh\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -577,10 +577,11 @@
 		C4A415721D0D579D00DC6018 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -592,6 +593,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.xor-gate.syncthing-macosx";
 				PRODUCT_NAME = Syncthing;
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = NO;
 				VALID_ARCHS = x86_64;
 			};
@@ -600,10 +602,11 @@
 		C4A415731D0D579D00DC6018 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer: jerryjacobs1989@gmail.com (TT7GM4W59N)";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -615,6 +618,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.xor-gate.syncthing-macosx";
 				PRODUCT_NAME = Syncthing;
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = YES;
 				VALID_ARCHS = x86_64;
 			};

--- a/syncthing/Scripts/create-dmg.sh
+++ b/syncthing/Scripts/create-dmg.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "${CONFIGURATION}" != "Release" ]; then
+	echo "[SKIP] Not building an Release configuration, skipping DMG creation"
+	exit
+fi
+
 SYNCTHING_DMG_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${PROJECT_DIR}/${INFOPLIST_FILE}")
 SYNCTHING_DMG="${BUILT_PRODUCTS_DIR}/Syncthing-${SYNCTHING_DMG_VERSION}.dmg"
 SYNCTHING_APP="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app"

--- a/syncthing/Scripts/create-dmg.sh
+++ b/syncthing/Scripts/create-dmg.sh
@@ -23,6 +23,12 @@ else
 	echo "   > ${SYNCTHING_DMG}"
 	mkdir -p ${STAGING_DIR}
 	cp -a -p ${SYNCTHING_APP} ${STAGING_DIR}
+	if [[ ! -z "${SYNCTHING_APP_CODE_SIGN_IDENTITY}" ]]; then
+		echo "-- Codesign with ${SYNCTHING_APP_CODE_SIGN_IDENTITY}"
+		codesign --force --deep --sign "${SYNCTHING_APP_CODE_SIGN_IDENTITY}" "${SYNCTHING_APP}"
+	else
+		echo "-- Skip codesign (variable SYNCTHING_APP_CODE_SIGN_IDENTITY unset)"
+	fi
 
 	${CREATE_DMG} \
 		--volname "Syncthing" \


### PR DESCRIPTION
This adds SYNCTHING_APP_CODE_SIGN_IDENTITY envvar injection. And fixes the DMG sign corruption. Also it is now required to have XCode 8.