### PR TITLE
Improved DMG generation and signing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ debug:
 	xcodebuild -derivedDataPath $(PWD) -configuration Debug -scheme syncthing
 release:
 	xcodebuild -derivedDataPath $(PWD) -configuration Release -scheme syncthing
-	xcodebuild build -derivedDataPath $(PWD) -configuration Release -scheme syncthing
+release-dmg:
+	xcodebuild -derivedDataPath $(PWD) -configuration Release -scheme syncthing-dmg
 clean:
 	rm -Rf Build

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ It will automaticly download syncthing amd64 binary and add it to the Applicatio
 For release builds signing the application build and creating an distributable DMG:
 
 ```
-SYNCTHING_APP_CODE_SIGN_IDENTITY="Mac Developer: foo@bar.com (XB59MXU8EC)" make release
+make release-dmg
+```
+
+The script will select the first available Developer ID and sign the app with it. To specify the signing identity, use `SYNCTHING_APP_CODE_SIGN_IDENTITY` environment variable:
+
+```
+SYNCTHING_APP_CODE_SIGN_IDENTITY="Mac Developer: foo@bar.com (XB59MXU8EC)" make release-dmg
 ```
 
 # Goal

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ make debug
 
 It will automaticly download syncthing amd64 binary and add it to the Application Bundle.
 
+For release builds signing the application build and creating an distributable DMG:
+
+```
+SYNCTHING_APP_CODE_SIGN_IDENTITY="Mac Developer: foo@bar.com (XB59MXU8EC)" make release
+```
+
 # Goal
 
 The goal of this project is to keep the Native Mac OS X Syncthing tray as simple as possible. No graphs, no advanced configuration

--- a/doc/design.md
+++ b/doc/design.md
@@ -13,5 +13,6 @@ Currently there is no need for having a separate version from syncthing.
 * Syncthing inotify resource is fetched with `syncthing/Scripts/syncthing-inotify-resource.sh`
 * Fancy DMG disk image is generated with `syncthing/Scripts/create-dmg.sh`
   * The version part of the DMG name is fetched from `syncthing/Info.plist, key CFBundleShortVersionString`
+* Both the app bundle and the DMG are signed with the first available Developer ID certificate, if found (or the one specified through SYNCTHING_APP_CODE_SIGN_IDENTITY environment variable)
 
 `syncthing-macosx` will only ship [stable releases and no release candidates](https://forum.syncthing.net/t/introducing-stable-releases-and-release-candidates/9167).

--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -6,6 +6,21 @@
 	objectVersion = 48;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		0B9C6B051F144DF1009C68CA /* syncthing-dmg */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 0B9C6B061F144DF1009C68CA /* Build configuration list for PBXAggregateTarget "syncthing-dmg" */;
+			buildPhases = (
+				0B889EB11F1451EF006E20E6 /* ShellScript */,
+			);
+			dependencies = (
+				0B9C6B0A1F144DF6009C68CA /* PBXTargetDependency */,
+			);
+			name = "syncthing-dmg";
+			productName = "syncthing-dmg";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		0BE9B88A1F050E93002883E2 /* STStatusMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE9B8891F050E93002883E2 /* STStatusMonitor.m */; };
 		C41E02A21D57D233006DD238 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41E02A11D57D233006DD238 /* Sparkle.framework */; };
@@ -38,6 +53,16 @@
 		C4F0E8391DA1CB0900435310 /* STPreferencesInfoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4F0E8371DA1CB0900435310 /* STPreferencesInfoViewController.xib */; };
 		C4FFB0661D0D7F870015D14A /* XGSyncthing.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FFB0641D0D7E4C0015D14A /* XGSyncthing.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0B9C6B091F144DF6009C68CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C4A415581D0D579D00DC6018 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C4A4155F1D0D579D00DC6018;
+			remoteInfo = syncthing;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		C4576BD91D11E3BB0031BCFD /* CopyFiles */ = {
@@ -355,6 +380,10 @@
 				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Jerry Jacobs";
 				TargetAttributes = {
+					0B9C6B051F144DF1009C68CA = {
+						CreatedOnToolsVersion = 8.3.3;
+						ProvisioningStyle = Automatic;
+					};
 					C4576BDA1D11E3BB0031BCFD = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
@@ -380,6 +409,7 @@
 			targets = (
 				C4A4155F1D0D579D00DC6018 /* syncthing */,
 				C4576BDA1D11E3BB0031BCFD /* xgsyncthing */,
+				0B9C6B051F144DF1009C68CA /* syncthing-dmg */,
 			);
 		};
 /* End PBXProject section */
@@ -405,6 +435,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0B889EB11F1451EF006E20E6 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${SOURCE_ROOT}/syncthing/Scripts/create-dmg.sh\n";
+		};
 		C4946AFF1D5876AF008447A2 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -454,6 +497,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		0B9C6B0A1F144DF6009C68CA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C4A4155F1D0D579D00DC6018 /* syncthing */;
+			targetProxy = 0B9C6B091F144DF6009C68CA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		C4A4156B1D0D579D00DC6018 /* STApplication.xib */ = {
 			isa = PBXVariantGroup;
@@ -466,6 +517,20 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0B9C6B071F144DF1009C68CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0B9C6B081F144DF1009C68CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		C4576BE01D11E3BB0031BCFD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -627,6 +692,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0B9C6B061F144DF1009C68CA /* Build configuration list for PBXAggregateTarget "syncthing-dmg" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0B9C6B071F144DF1009C68CA /* Debug */,
+				0B9C6B081F144DF1009C68CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C4576BDF1D11E3BB0031BCFD /* Build configuration list for PBXNativeTarget "xgsyncthing" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -603,7 +603,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "";
 				DEVELOPMENT_TEAM = "";

--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -366,7 +366,7 @@
 				};
 			};
 			buildConfigurationList = C4A4155B1D0D579D00DC6018 /* Build configuration list for PBXProject "syncthing" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -416,7 +416,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SOURCE_ROOT}/syncthing/Scripts/syncthing-resource.sh\n${SOURCE_ROOT}/syncthing/Scripts/syncthing-inotify-resource.sh\n${SOURCE_ROOT}/syncthing/Scripts/create-dmg.sh";
+			shellScript = "${SOURCE_ROOT}/syncthing/Scripts/syncthing-resource.sh\n${SOURCE_ROOT}/syncthing/Scripts/syncthing-inotify-resource.sh\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -577,10 +577,11 @@
 		C4A415721D0D579D00DC6018 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -592,6 +593,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.xor-gate.syncthing-macosx";
 				PRODUCT_NAME = Syncthing;
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = NO;
 				VALID_ARCHS = x86_64;
 			};
@@ -600,10 +602,11 @@
 		C4A415731D0D579D00DC6018 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer: jerryjacobs1989@gmail.com (TT7GM4W59N)";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -615,6 +618,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.xor-gate.syncthing-macosx";
 				PRODUCT_NAME = Syncthing;
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = YES;
 				VALID_ARCHS = x86_64;
 			};

--- a/syncthing/Scripts/create-dmg.sh
+++ b/syncthing/Scripts/create-dmg.sh
@@ -6,14 +6,16 @@ if [ "${CONFIGURATION}" != "Release" ]; then
 	exit
 fi
 
-SYNCTHING_DMG_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${PROJECT_DIR}/${INFOPLIST_FILE}")
+SYNCTHING_DMG_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${PROJECT_DIR}/syncthing/Info.plist")
 SYNCTHING_DMG="${BUILT_PRODUCTS_DIR}/Syncthing-${SYNCTHING_DMG_VERSION}.dmg"
-SYNCTHING_APP="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app"
-SYNCTHING_APP_RESOURCES="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Resources"
+SYNCTHING_APP="${BUILT_PRODUCTS_DIR}/Syncthing.app"
+SYNCTHING_APP_RESOURCES="${SYNCTHING_APP}/Contents/Resources"
 
 CREATE_DMG="${SOURCE_ROOT}/3thparty/github.com/andreyvit/create-dmg/create-dmg"
 STAGING_DIR="${BUILT_PRODUCTS_DIR}/staging/dmg"
+STAGING_APP="${STAGING_DIR}/Syncthing.app"
 DMG_TEMPLATE_DIR="${SOURCE_ROOT}/syncthing/Templates/DMG"
+DEFAULT_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID" | head -1 | cut -f 4 -d " " || true)
 
 if [ -f "${SYNCTHING_DMG}" ]; then
 	echo "-- Syncthing dmg already created"
@@ -21,13 +23,23 @@ if [ -f "${SYNCTHING_DMG}" ]; then
 else
 	echo "-- Creating syncthing dmg"
 	echo "   > ${SYNCTHING_DMG}"
+	rm -rf ${STAGING_DIR}
 	mkdir -p ${STAGING_DIR}
 	cp -a -p ${SYNCTHING_APP} ${STAGING_DIR}
-	if [[ ! -z "${SYNCTHING_APP_CODE_SIGN_IDENTITY}" ]]; then
+
+	if [[ ! -z "${SYNCTHING_APP_CODE_SIGN_IDENTITY+x}" ]]; then
 		echo "-- Codesign with ${SYNCTHING_APP_CODE_SIGN_IDENTITY}"
-		codesign --force --deep --sign "${SYNCTHING_APP_CODE_SIGN_IDENTITY}" "${SYNCTHING_APP}"
+		SELECTED_IDENTITY="${SYNCTHING_APP_CODE_SIGN_IDENTITY}"
+	elif [[ ! -z "${DEFAULT_IDENTITY}" ]]; then
+		echo "-- Using first valid identity (variable SYNCTHING_APP_CODE_SIGN_IDENTITY unset)"
+		SELECTED_IDENTITY="${DEFAULT_IDENTITY}"
 	else
-		echo "-- Skip codesign (variable SYNCTHING_APP_CODE_SIGN_IDENTITY unset)"
+		echo "-- Skip codesign (variable SYNCTHING_APP_CODE_SIGN_IDENTITY unset and no Developer ID identity found)"
+		SELECTED_IDENTITY=""
+	fi
+
+	if [[ ! -z "${SELECTED_IDENTITY}" ]]; then
+		codesign --force --deep --sign "${SELECTED_IDENTITY}" "${STAGING_APP}"
 	fi
 
 	${CREATE_DMG} \
@@ -41,4 +53,8 @@ else
 		--app-drop-link 240 380 \
 		${SYNCTHING_DMG} \
 		${STAGING_DIR}
+
+	if [[ ! -z "${SELECTED_IDENTITY}" ]]; then
+		codesign --sign "${SELECTED_IDENTITY}" "${SYNCTHING_DMG}"
+	fi
 fi

--- a/syncthing/Scripts/create-dmg.sh
+++ b/syncthing/Scripts/create-dmg.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "${CONFIGURATION}" != "Release" ]; then
+	echo "[SKIP] Not building an Release configuration, skipping DMG creation"
+	exit
+fi
+
 SYNCTHING_DMG_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${PROJECT_DIR}/${INFOPLIST_FILE}")
 SYNCTHING_DMG="${BUILT_PRODUCTS_DIR}/Syncthing-${SYNCTHING_DMG_VERSION}.dmg"
 SYNCTHING_APP="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app"

--- a/syncthing/Scripts/create-dmg.sh
+++ b/syncthing/Scripts/create-dmg.sh
@@ -23,6 +23,12 @@ else
 	echo "   > ${SYNCTHING_DMG}"
 	mkdir -p ${STAGING_DIR}
 	cp -a -p ${SYNCTHING_APP} ${STAGING_DIR}
+	if [[ ! -z "${SYNCTHING_APP_CODE_SIGN_IDENTITY}" ]]; then
+		echo "-- Codesign with ${SYNCTHING_APP_CODE_SIGN_IDENTITY}"
+		codesign --force --deep --sign "${SYNCTHING_APP_CODE_SIGN_IDENTITY}" "${SYNCTHING_APP}"
+	else
+		echo "-- Skip codesign (variable SYNCTHING_APP_CODE_SIGN_IDENTITY unset)"
+	fi
 
 	${CREATE_DMG} \
 		--volname "Syncthing" \


### PR DESCRIPTION
Added a new target – syncthing-dmg, that generates and signs the DMG with the first available Developer ID certificate, if found (or the one specified through SYNCTHING_APP_CODE_SIGN_IDENTITY environment variable)