### PR TITLE
appcast: Prepare for 0.14.46-1 release

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,18 @@
 		<description>Most recent changes with links to updates.</description>
 		<language>en</language>
 		<item>
+                        <title>Version 0.14.46-1</title>
+                        <sparkle:releaseNotesLink>https://xor-gate.github.io/syncthing-macosx/releases/0.14.46-1.html</sparkle:releaseNotesLink>
+                        <pubDate>TBD</pubDate>
+                        <enclosure
+                                   sparkle:shortVersionString="0.14.46-1"
+                                   sparkle:version="0144601"
+                                   type="application/octet-stream"
+                                   url="https://github.com/xor-gate/syncthing-macosx/releases/download/v0.14.46-1/Syncthing-0.14.46-1.dmg"
+                        />
+        </item>
+
+		<item>
                         <title>Version 0.14.8-2</title>
                         <sparkle:releaseNotesLink>https://xor-gate.github.io/syncthing-macosx/releases/0.14.8-2.html</sparkle:releaseNotesLink>
                         <pubDate>Sun, 16 Okt 2016 17:11:00 GMT+2</pubDate>

--- a/appcast.xml
+++ b/appcast.xml
@@ -8,7 +8,7 @@
 		<item>
                         <title>Version 0.14.46-1</title>
                         <sparkle:releaseNotesLink>https://xor-gate.github.io/syncthing-macosx/releases/0.14.46-1.html</sparkle:releaseNotesLink>
-                        <pubDate>TBD</pubDate>
+                        <pubDate>Thu, 19 Apr 2018 21:36:00 GMT+2</pubDate>
                         <enclosure
                                    sparkle:shortVersionString="0.14.46-1"
                                    sparkle:version="0144601"

--- a/releases/0.14.46-1.html
+++ b/releases/0.14.46-1.html
@@ -3,7 +3,7 @@ People who still run syncthing-macosx 0.14.8-2 bundle need to manual upgrade to 
 </p>
 
 <h3>Changes</h3>
-<p>For a complete list of changes see <a href="https://github.com/xor-gate/syncthing-macosx/releases/tag/v0.14.46-1"><tt>v0.14.46-1</tt></a></p>
+<p>For a complete list of changes see <a href="https://github.com/xor-gate/syncthing-macosx/compare/v0.14.33-1...v0.14.46-1"><tt>v0.14.33-1...v0.14.46-1</tt></a></p>
 <ul>
 	<li>Add items to menu</li>
 	<ul>

--- a/releases/0.14.46-1.html
+++ b/releases/0.14.46-1.html
@@ -1,0 +1,14 @@
+<h3>NOTICE</h3>
+People who still run syncthing-macosx 0.14.8-2 bundle need to manual upgrade to this version. The old application needs to be replaced because it now uses different sign keys (for more information see <a href="https://github.com/xor-gate/syncthing-macosx/issues/8#issuecomment-319902371">issue #8</a>). It can be downloaded from <a href="https://github.com/xor-gate/syncthing-macosx/releases/latest">github.com</a>
+</p>
+
+<h3>Changes</h3>
+<p>For a complete list of changes see <a href="https://github.com/xor-gate/syncthing-macosx/releases/tag/v0.14.46-1"><tt>v0.14.46-1</tt></a></p>
+<ul>
+	<li>Add items to menu</li>
+	<ul>
+		<li>Pause All Devices</li>
+		<li>Resume All Devices</li>
+		<li>Rescan All</li>
+	</ul>
+</ul>


### PR DESCRIPTION
When the bundle is build and tagged we must update the appcast on github pages for Sparkle update channel.
@virusman the PR is now here so you can have a look.