### PR TITLE
Delay reconnect attempts if the server returned an error

### DIFF
--- a/syncthing/STStatusMonitor.m
+++ b/syncthing/STStatusMonitor.m
@@ -64,6 +64,12 @@
             self.lastSeenId = 0;
             [NSThread sleepForTimeInterval:1.0];
         }
+        
+        NSInteger statusCode = ((NSHTTPURLResponse *)serverResponse).statusCode;
+        if (myError != nil || statusCode >= 400) {
+            // Retry after delay if the server returned an error
+            [NSThread sleepForTimeInterval:1.0];
+        }
     }
     
     if (self.enabled)


### PR DESCRIPTION
This should fix high CPU usage issue when API key is invalid
Fixes #46