### PR TITLE
Refactor HTTP(S) handling (fixes #24)

### DIFF
--- a/LocalhostTLSDelegate.h
+++ b/LocalhostTLSDelegate.h
@@ -1,0 +1,13 @@
+//
+//  LocalhostTLSDelegate.h
+//  syncthing
+//
+//  Created by Jakob Borg on 2018-07-28.
+//  Copyright © 2018 Jerry Jacobs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface LocalhostTLSDelegate : NSObject <NSURLSessionDelegate>
+
+@end

--- a/LocalhostTLSDelegate.m
+++ b/LocalhostTLSDelegate.m
@@ -1,0 +1,32 @@
+//
+//  LocalhostTLSDelegate.m
+//  syncthing
+//
+//  Created by Jakob Borg on 2018-07-28.
+//  Copyright © 2018 Jerry Jacobs. All rights reserved.
+//
+
+#import "LocalhostTLSDelegate.h"
+
+@implementation LocalhostTLSDelegate
+
+- (void) URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler {
+    if (challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust) {
+        // We're doing something other than checking a server certificate.
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+        return;
+    }
+
+    if ([challenge.protectionSpace.host isEqualToString:@"localhost"] ||
+        [challenge.protectionSpace.host isEqualToString:@"127.0.0.1"] ||
+        [challenge.protectionSpace.host isEqualToString:@"::1"]) {
+        // We're looking at localhost. Accept any certificate.
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+        return;
+    }
+
+    // Perform the default processing.
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ The goal of this project is to keep the Native Mac OS X Syncthing tray as simple
 
 # Known bugs
 
-* Issue [#24](https://github.com/xor-gate/syncthing-macosx/issues/24): HTTPS with self signed certificate doesn't work and gives no usefull error.
-  * Workaround: Disable HTTPS
+See the [issue tracker](https://github.com/syncthing/syncthing-macos/issues)for the current status.
 
 # Design
 
@@ -74,7 +73,7 @@ Design, internals and build process is documented in [doc/design.md](doc/design.
 
 Contributions and issue reports are welcome. I'm an beginner in programming in Objective-C.
  Please keep in mind I do this on best-effort basis, and I try not to break the auto-updater.
- 
+
 I'm willing to add donated-based features if you need them.
 
 # License

--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 
 /* Begin PBXBuildFile section */
 		0BE9B88A1F050E93002883E2 /* STStatusMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE9B8891F050E93002883E2 /* STStatusMonitor.m */; };
+		296DB6DF210D120B0076692E /* LocalhostTLSDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DB6DE210D120B0076692E /* LocalhostTLSDelegate.m */; };
+		296DB6E0210D12170076692E /* LocalhostTLSDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DB6DE210D120B0076692E /* LocalhostTLSDelegate.m */; };
 		C4460A801D0DD2D500200C21 /* STPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C4460A7D1D0DD2D500200C21 /* STPreferencesWindowController.m */; };
 		C4460A811D0DD2D500200C21 /* STStatusBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = C4460A7F1D0DD2D500200C21 /* STStatusBarController.m */; };
 		C4460A831D0DD38F00200C21 /* STPreferencesWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4460A821D0DD38F00200C21 /* STPreferencesWindowController.xib */; };
@@ -87,6 +89,8 @@
 /* Begin PBXFileReference section */
 		0BE9B8881F050E93002883E2 /* STStatusMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STStatusMonitor.h; sourceTree = "<group>"; };
 		0BE9B8891F050E93002883E2 /* STStatusMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STStatusMonitor.m; sourceTree = "<group>"; };
+		296DB6DD210D120B0076692E /* LocalhostTLSDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalhostTLSDelegate.h; sourceTree = "<group>"; };
+		296DB6DE210D120B0076692E /* LocalhostTLSDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocalhostTLSDelegate.m; sourceTree = "<group>"; };
 		29CC334D4211142108D2F82C /* Pods-syncthing.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-syncthing.release.xcconfig"; path = "Pods/Target Support Files/Pods-syncthing/Pods-syncthing.release.xcconfig"; sourceTree = "<group>"; };
 		5BE33EE7B1F21764C8AA4890 /* Pods-xgsyncthing.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xgsyncthing.release.xcconfig"; path = "Pods/Target Support Files/Pods-xgsyncthing/Pods-xgsyncthing.release.xcconfig"; sourceTree = "<group>"; };
 		8936500B5F25163F49F1401D /* Pods-xgsyncthing.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xgsyncthing.debug.xcconfig"; path = "Pods/Target Support Files/Pods-xgsyncthing/Pods-xgsyncthing.debug.xcconfig"; sourceTree = "<group>"; };
@@ -336,6 +340,8 @@
 				C4576BE21D11E40E0031BCFD /* Test */,
 				C4FFB0641D0D7E4C0015D14A /* XGSyncthing.m */,
 				C4FFB0631D0D7E440015D14A /* XGSyncthing.h */,
+				296DB6DD210D120B0076692E /* LocalhostTLSDelegate.h */,
+				296DB6DE210D120B0076692E /* LocalhostTLSDelegate.m */,
 			);
 			name = Library;
 			sourceTree = "<group>";
@@ -538,6 +544,7 @@
 			files = (
 				C4576BEB1D11E9280031BCFD /* XGSyncthing.m in Sources */,
 				C4576BE41D11E43C0031BCFD /* main.m in Sources */,
+				296DB6E0210D12170076692E /* LocalhostTLSDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -547,6 +554,7 @@
 			files = (
 				C4D567A21D3A8DFE002AD881 /* STLoginItem.m in Sources */,
 				C4FFB0661D0D7F870015D14A /* XGSyncthing.m in Sources */,
+				296DB6DF210D120B0076692E /* LocalhostTLSDelegate.m in Sources */,
 				C4F0E8331DA1C7A800435310 /* STPreferencesFoldersViewController.m in Sources */,
 				C4A415681D0D579D00DC6018 /* main.m in Sources */,
 				C4946B031D587878008447A2 /* STAboutWindowController.m in Sources */,

--- a/syncthing/STStatusMonitor.m
+++ b/syncthing/STStatusMonitor.m
@@ -22,62 +22,26 @@
 
 - (instancetype)init {
     self = [super init];
-    
+
     self.folderStates = [[NSMutableDictionary alloc] init];
-    
+
     return self;
 }
 
 - (void) longPoll {
     @autoreleasepool {
-        NSString *url = nil;
-        NSTimeInterval timeout = 60.0;
-
-        if (self.lastSeenId) {
-            // Ask for new events with a timeout of one second less than our
-            // hard request timeout. If there are no events we will get an
-            // empty even list at the soft timeout.
-            url = [NSString stringWithFormat:@"%@/rest/events?since=%ld&timeout=%.0f", self.syncthing.URI, self.lastSeenId, timeout - 1.0];
-        }
-        else {
-            url = [NSString stringWithFormat:@"%@/rest/events?limit=1", self.syncthing.URI];
-        }
-        
-        NSData *serverData = nil;
-        NSError *myError = nil;
-        NSURLResponse *serverResponse = nil;
-        NSMutableURLRequest *theRequest=[NSMutableURLRequest
-                                         requestWithURL:[NSURL URLWithString:url]
-                                         cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:timeout];
-
-        [theRequest setHTTPMethod:@"GET"];
-        [theRequest setValue:self.syncthing.ApiKey forHTTPHeaderField:@"X-API-Key"];
-        
-        serverData = [NSURLConnection sendSynchronousRequest:theRequest
-                                           returningResponse:&serverResponse error:&myError];
-        
-        if (!myError) {
-            id json = [NSJSONSerialization JSONObjectWithData:serverData options:
-                       NSJSONReadingMutableContainers error:&myError];
-            
-            
-            [self performSelectorOnMainThread:@selector(dataReceived:)
-                                   withObject:json waitUntilDone:YES];
-        }
-        else if ([[myError domain] isEqualToString:@"NSURLErrorDomain"] && [myError code] != NSURLErrorTimedOut) {
-            self.lastSeenId = 0;
+        id result = [self.syncthing getEventsSince:self.lastSeenId];
+        if (result == nil) {
+            // Failed to get events
             [NSThread sleepForTimeInterval:1.0];
+        } else {
+            // Got events, process them.
+            [self performSelectorOnMainThread:@selector(dataReceived:) withObject:result waitUntilDone:YES];
         }
         
-        NSInteger statusCode = ((NSHTTPURLResponse *)serverResponse).statusCode;
-        if (myError != nil || statusCode >= 400) {
-            // Retry after delay if the server returned an error
-            [NSThread sleepForTimeInterval:1.0];
-        }
+        if (self.enabled)
+            [self performSelectorInBackground:@selector(longPoll) withObject: nil];
     }
-    
-    if (self.enabled)
-        [self performSelectorInBackground:@selector(longPoll) withObject: nil];
 }
 
 - (void) dataReceived: (id) data {
@@ -97,7 +61,7 @@
     if ([eventType isEqualToString:@"StateChanged"]) {
         NSString *folder = [eventData objectForKey:@"folder"];
         NSString *newState = [eventData objectForKey:@"to"];
-        
+
         self.folderStates[folder] = newState;
         [self updateCurrentStatus];
     }
@@ -138,7 +102,7 @@
     if (!self.enabled) {
         self.enabled = YES;
         [self performSelectorInBackground:@selector(longPoll) withObject: nil];
-        
+
         _updateTimer = [NSTimer scheduledTimerWithTimeInterval:5 target:self selector:@selector(updateStatusFromTimer) userInfo:nil repeats:YES];
     }
 }

--- a/syncthing/XGSyncthing.h
+++ b/syncthing/XGSyncthing.h
@@ -28,6 +28,7 @@
 - (void)pauseAllDevices;
 - (void)resumeAllDevices;
 - (void)rescanAll;
+- (id)getEventsSince:(long)since;
 
 /**
  * Load configuration from XML file

--- a/syncthing/XGSyncthing.m
+++ b/syncthing/XGSyncthing.m
@@ -1,10 +1,15 @@
 #import "XGSyncthing.h"
+#import "LocalhostTLSDelegate.h"
+
+// How long we wait for one event poll
+#define EVENT_TIMEOUT 60.0
 
 @interface XGSyncthing()
 
 @property NSTask *StTask;
 @property (nonatomic, strong) NSXMLParser *configParser;
 @property (nonatomic, strong) NSMutableArray<NSString *> *parsing;
+@property (nonatomic, strong) NSURLSession *session;
 
 @end
 
@@ -17,7 +22,7 @@
 - (bool) runExecutable
 {
     _StTask = [[NSTask alloc] init];
-    
+
     [_StTask setLaunchPath:_Executable];
     [_StTask setArguments:@[@"-no-browser"]];
     [_StTask setQualityOfService:NSQualityOfServiceBackground];
@@ -30,32 +35,50 @@
 {
     if (!_StTask)
         return;
-    
+
     [_StTask interrupt];
     [_StTask waitUntilExit];
 }
 
 - (id)sendRequestToEndpoint:(NSString *)endpoint method:(NSString *)method parameters:(NSDictionary *)parameters
 {
-    NSData *serverData = nil;
-    NSError *myError = nil;
-    NSURLResponse *serverResponse = nil;
-    NSMutableURLRequest *theRequest=[NSMutableURLRequest
-                                     requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@", _URI, endpoint]]
-                                     cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10.0];
-    
+    if (self.session == nil) {
+        // Lazy create a reasonable URLSession
+        NSURLSessionConfiguration *cfg = [NSURLSessionConfiguration defaultSessionConfiguration];
+        self.session = [NSURLSession sessionWithConfiguration:cfg delegate:[[LocalhostTLSDelegate alloc] init] delegateQueue:nil];
+    }
+
+    // Create the URL from base, endpoint and params.
+    NSURLComponents *comps = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"%@%@", _URI, endpoint]];
+    NSMutableArray *queryItems = [NSMutableArray array];
+    for (NSString *key in parameters) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:key value:[NSString stringWithFormat:@"%@", parameters[key]]]];
+    }
+    comps.queryItems = queryItems;
+
+    NSMutableURLRequest *theRequest = [NSMutableURLRequest
+                                       requestWithURL:[comps URL]
+                                       cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10.0];
+
     [theRequest setHTTPMethod:method];
     [theRequest setValue:_apiKey forHTTPHeaderField:@"X-API-Key"];
-    
-    serverData = [NSURLConnection sendSynchronousRequest:theRequest
-                                       returningResponse:&serverResponse error:&myError];
-    
-    if (myError)
-        return nil;
-    
-    id json = [NSJSONSerialization JSONObjectWithData:serverData options:
-               NSJSONReadingMutableContainers error:&myError];
-    return json;
+    [theRequest setTimeoutInterval:EVENT_TIMEOUT + 5.0]; // slightly more than the Syncthing event timeout
+
+    __block id result = nil;
+    dispatch_semaphore_t done = dispatch_semaphore_create(0);
+
+    NSURLSessionTask *task = [self.session dataTaskWithRequest:theRequest completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if (error != nil) {
+            dispatch_semaphore_signal(done);
+            return;
+        }
+        result = [NSJSONSerialization JSONObjectWithData:data options: NSJSONReadingMutableContainers error:&error];
+        dispatch_semaphore_signal(done);
+    }];
+    [task resume];
+
+    dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
+    return result;
 }
 
 - (id)sendGetRequestToEndpoint:(NSString *)endpoint parameters:(NSDictionary *)parameters
@@ -71,7 +94,7 @@
 - (bool)ping
 {
     id json = [self sendGetRequestToEndpoint:@"/rest/system/ping" parameters:nil];
-    
+
 	if ([[json objectForKey:@"ping"] isEqualToString:@"pong"])
 		return true;
 	return false;
@@ -118,6 +141,24 @@
     [self sendPostRequestToEndpoint:@"/rest/db/scan" parameters:nil];
 }
 
+- (id)getEventsSince:(long)since
+{
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    if (since > 0) {
+        // Get events since the last once seen, waiting at most EVENT_TIMEOUT s.
+        [params setValue:[NSNumber numberWithLong:since] forKey:@"since"];
+        [params setValue:[NSNumber numberWithFloat:EVENT_TIMEOUT] forKey:@"timeout"];
+    }
+    else {
+        // Get the last event, whatever it is.
+        [params setValue:[NSNumber numberWithInt:1] forKey:@"limit"];
+    }
+    // TODO(jb): We should specify which events we're interested in,
+    // exactly. Both to avoid the firehose and also to avoid Syncthing
+    // changing stuff underneath our feet in the future.
+    return [self sendGetRequestToEndpoint:@"/rest/events" parameters:params];
+}
+
 - (BOOL)loadConfigurationFromXML
 {
     NSError* error;
@@ -136,7 +177,7 @@
 -(void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary<NSString *,NSString *> *)attributeDict {
     [_parsing addObject:elementName];
     NSString *keyPath = [_parsing componentsJoinedByString:@"."];
-    
+
     if ([keyPath isEqualToString:@"configuration.gui"]) {
         if ([[[attributeDict objectForKey:@"tls"] lowercaseString] isEqualToString:@"true"]) {
             _URI = @"https://";
@@ -152,7 +193,7 @@
 
 -(void)parser:(NSXMLParser *)parser foundCharacters:(NSString *)string {
     NSString *keyPath = [_parsing componentsJoinedByString:@"."];
-    
+
     if ([keyPath isEqualToString:@"configuration.gui.apikey"]) {
         _apiKey = string;
     } else if  ([keyPath isEqualToString:@"configuration.gui.address"]) {


### PR DESCRIPTION
This moves event getting into the XGSyncthing library, while also refactoring it to use NSURLSession, a delegate for allowing local TLS certificates, and proper parameters.

The delegate simply skips HTTPS certificate checking on hosts called "localhost", "127.0.0.1", or "::1". I think this is what most people would want from this tool.

I've just tested it manually:

<img width="532" alt="screen shot 2018-07-29 at 00 06 13" src="https://user-images.githubusercontent.com/125426/43360960-3bb04142-92c3-11e8-8a16-a31b5ed912ad.png">
