### PR TITLE
Add daemon process handling (fixes #48)

### DIFF
--- a/syncthing.xcodeproj/project.pbxproj
+++ b/syncthing.xcodeproj/project.pbxproj
@@ -24,7 +24,8 @@
 /* Begin PBXBuildFile section */
 		0BE9B88A1F050E93002883E2 /* STStatusMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE9B8891F050E93002883E2 /* STStatusMonitor.m */; };
 		298A5C45210DA6C40034B89F /* LocalhostTLSDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 298A5C43210DA6C40034B89F /* LocalhostTLSDelegate.m */; };
-		298A5C46210DA70D0034B89F /* LocalhostTLSDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 298A5C43210DA6C40034B89F /* LocalhostTLSDelegate.m */; };
+		29AF1BA3210F11BF004212DE /* DaemonProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AFA4CD210F10FA00071E5E /* DaemonProcess.swift */; };
+		29AFA4CF210F10FB00071E5E /* DaemonProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AFA4CD210F10FA00071E5E /* DaemonProcess.swift */; };
 		C4460A801D0DD2D500200C21 /* STPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C4460A7D1D0DD2D500200C21 /* STPreferencesWindowController.m */; };
 		C4460A811D0DD2D500200C21 /* STStatusBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = C4460A7F1D0DD2D500200C21 /* STStatusBarController.m */; };
 		C4460A831D0DD38F00200C21 /* STPreferencesWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4460A821D0DD38F00200C21 /* STPreferencesWindowController.xib */; };
@@ -91,6 +92,8 @@
 		0BE9B8891F050E93002883E2 /* STStatusMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STStatusMonitor.m; sourceTree = "<group>"; };
 		298A5C43210DA6C40034B89F /* LocalhostTLSDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LocalhostTLSDelegate.m; path = syncthing/LocalhostTLSDelegate.m; sourceTree = "<group>"; };
 		298A5C44210DA6C40034B89F /* LocalhostTLSDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LocalhostTLSDelegate.h; path = syncthing/LocalhostTLSDelegate.h; sourceTree = "<group>"; };
+		29AF1BA4210F11DE004212DE /* syncthing-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "syncthing-Bridging-Header.h"; path = "syncthing/syncthing-Bridging-Header.h"; sourceTree = "<group>"; };
+		29AFA4CD210F10FA00071E5E /* DaemonProcess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DaemonProcess.swift; path = syncthing/DaemonProcess.swift; sourceTree = "<group>"; };
 		29CC334D4211142108D2F82C /* Pods-syncthing.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-syncthing.release.xcconfig"; path = "Pods/Target Support Files/Pods-syncthing/Pods-syncthing.release.xcconfig"; sourceTree = "<group>"; };
 		5BE33EE7B1F21764C8AA4890 /* Pods-xgsyncthing.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xgsyncthing.release.xcconfig"; path = "Pods/Target Support Files/Pods-xgsyncthing/Pods-xgsyncthing.release.xcconfig"; sourceTree = "<group>"; };
 		8936500B5F25163F49F1401D /* Pods-xgsyncthing.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xgsyncthing.debug.xcconfig"; path = "Pods/Target Support Files/Pods-xgsyncthing/Pods-xgsyncthing.debug.xcconfig"; sourceTree = "<group>"; };
@@ -338,6 +341,8 @@
 			isa = PBXGroup;
 			children = (
 				C4576BE21D11E40E0031BCFD /* Test */,
+				29AF1BA4210F11DE004212DE /* syncthing-Bridging-Header.h */,
+				29AFA4CD210F10FA00071E5E /* DaemonProcess.swift */,
 				298A5C44210DA6C40034B89F /* LocalhostTLSDelegate.h */,
 				298A5C43210DA6C40034B89F /* LocalhostTLSDelegate.m */,
 				C4FFB0631D0D7E440015D14A /* XGSyncthing.h */,
@@ -403,10 +408,12 @@
 					};
 					C4576BDA1D11E3BB0031BCFD = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0940;
 					};
 					C4A4155F1D0D579D00DC6018 = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = C24U83K674;
+						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -543,8 +550,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4576BEB1D11E9280031BCFD /* XGSyncthing.m in Sources */,
+				29AFA4CF210F10FB00071E5E /* DaemonProcess.swift in Sources */,
 				C4576BE41D11E43C0031BCFD /* main.m in Sources */,
-				298A5C46210DA70D0034B89F /* LocalhostTLSDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -553,6 +560,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4D567A21D3A8DFE002AD881 /* STLoginItem.m in Sources */,
+				29AF1BA3210F11BF004212DE /* DaemonProcess.swift in Sources */,
 				C4FFB0661D0D7F870015D14A /* XGSyncthing.m in Sources */,
 				298A5C45210DA6C40034B89F /* LocalhostTLSDelegate.m in Sources */,
 				C4F0E8331DA1C7A800435310 /* STPreferencesFoldersViewController.m in Sources */,
@@ -610,11 +618,15 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8936500B5F25163F49F1401D /* Pods-xgsyncthing.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				OTHER_CFLAGS = "";
 				"OTHER_LDFLAGS[arch=*]" = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -622,9 +634,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5BE33EE7B1F21764C8AA4890 /* Pods-xgsyncthing.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -720,6 +735,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FB3E4EE48CFC608AD4FBDE77 /* Pods-syncthing.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -738,6 +754,9 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "syncthing/syncthing-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
@@ -746,6 +765,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 29CC334D4211142108D2F82C /* Pods-syncthing.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -764,6 +784,8 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "syncthing/syncthing-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = x86_64;
 			};
 			name = Release;

--- a/syncthing/Base.lproj/STApplication.xib
+++ b/syncthing/Base.lproj/STApplication.xib
@@ -62,6 +62,7 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem isSeparatorItem="YES" id="Qhv-cP-g7k"/>
                 <menuItem title="Open" toolTip="Open Syncthing Web GUI" id="euz-4I-RQa">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>

--- a/syncthing/Base.lproj/STApplication.xib
+++ b/syncthing/Base.lproj/STApplication.xib
@@ -11,7 +11,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="STAppDelegate">
             <connections>
                 <outlet property="Menu" destination="FYW-KQ-yxY" id="plp-7h-Wj2"/>
@@ -29,9 +29,9 @@
             <items>
                 <menuItem title="Status" image="NSStatusUnavailable" id="PGw-J9-KII">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="Status" showsStateColumn="NO" autoenablesItems="NO" id="qS5-d4-4WD">
+                    <menu key="submenu" title="Status" autoenablesItems="NO" id="qS5-d4-4WD">
                         <items>
-                            <menuItem title="Connection" image="NSStatusUnavailable" id="Gzh-BA-qbg">
+                            <menuItem title="Connection" image="NSStatusUnavailable" enabled="NO" id="Gzh-BA-qbg">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem title="Daemon" image="NSStatusUnavailable" id="MAH-El-s0y">

--- a/syncthing/Base.lproj/STApplication.xib
+++ b/syncthing/Base.lproj/STApplication.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -11,16 +11,57 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="-3" userLabel="Application"/>
         <customObject id="Voe-Tx-rLC" customClass="STAppDelegate">
             <connections>
                 <outlet property="Menu" destination="FYW-KQ-yxY" id="plp-7h-Wj2"/>
+                <outlet property="connectionStatusMenuItem" destination="Gzh-BA-qbg" id="Qsf-SM-5Ew"/>
+                <outlet property="daemonRestartMenuItem" destination="24n-vt-eof" id="D3g-69-jyJ"/>
+                <outlet property="daemonStartMenuItem" destination="s51-hi-aSO" id="8qL-OZ-Raj"/>
+                <outlet property="daemonStatusMenuItem" destination="MAH-El-s0y" id="Lv4-ej-d0h"/>
+                <outlet property="daemonStopMenuItem" destination="v6W-XD-Nuf" id="jJ8-t9-Dwq"/>
+                <outlet property="statusMenuItem" destination="PGw-J9-KII" id="zfN-9R-I9K"/>
                 <outlet property="toggleAllDevicesItem" destination="kBF-aK-W8P" id="ITn-Le-nZi"/>
             </connections>
         </customObject>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu id="FYW-KQ-yxY">
             <items>
+                <menuItem title="Status" image="NSStatusUnavailable" id="PGw-J9-KII">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Status" showsStateColumn="NO" autoenablesItems="NO" id="qS5-d4-4WD">
+                        <items>
+                            <menuItem title="Connection" image="NSStatusUnavailable" id="Gzh-BA-qbg">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
+                            <menuItem title="Daemon" image="NSStatusUnavailable" id="MAH-El-s0y">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Daemon" autoenablesItems="NO" id="YYN-1k-umQ">
+                                    <items>
+                                        <menuItem title="Start" id="s51-hi-aSO">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="clickedDaemonStart:" target="Voe-Tx-rLC" id="48u-8L-C1K"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Stop" enabled="NO" id="v6W-XD-Nuf">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="clickedDaemonStop:" target="Voe-Tx-rLC" id="yBD-4Z-Q0Z"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Restart" enabled="NO" id="24n-vt-eof">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="clickedDaemonRestart:" target="Voe-Tx-rLC" id="KwT-ej-jdO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
                 <menuItem title="Open" toolTip="Open Syncthing Web GUI" id="euz-4I-RQa">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
@@ -154,4 +195,7 @@
             </menu>
         </menuItem>
     </objects>
+    <resources>
+        <image name="NSStatusUnavailable" width="16" height="16"/>
+    </resources>
 </document>

--- a/syncthing/Base.lproj/STApplication.xib
+++ b/syncthing/Base.lproj/STApplication.xib
@@ -31,9 +31,9 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Status" autoenablesItems="NO" id="qS5-d4-4WD">
                         <items>
-                            <menuItem title="Background Service" image="NSStatusUnavailable" id="MAH-El-s0y">
+                            <menuItem title="Syncthing Service" image="NSStatusUnavailable" id="MAH-El-s0y">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Background Service" autoenablesItems="NO" id="YYN-1k-umQ">
+                                <menu key="submenu" title="Syncthing Service" autoenablesItems="NO" id="YYN-1k-umQ">
                                     <items>
                                         <menuItem title="Start" id="s51-hi-aSO">
                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/syncthing/Base.lproj/STApplication.xib
+++ b/syncthing/Base.lproj/STApplication.xib
@@ -31,12 +31,9 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Status" autoenablesItems="NO" id="qS5-d4-4WD">
                         <items>
-                            <menuItem title="Connection" image="NSStatusUnavailable" enabled="NO" id="Gzh-BA-qbg">
+                            <menuItem title="Background Service" image="NSStatusUnavailable" id="MAH-El-s0y">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                            </menuItem>
-                            <menuItem title="Daemon" image="NSStatusUnavailable" id="MAH-El-s0y">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Daemon" autoenablesItems="NO" id="YYN-1k-umQ">
+                                <menu key="submenu" title="Background Service" autoenablesItems="NO" id="YYN-1k-umQ">
                                     <items>
                                         <menuItem title="Start" id="s51-hi-aSO">
                                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -58,6 +55,9 @@
                                         </menuItem>
                                     </items>
                                 </menu>
+                            </menuItem>
+                            <menuItem title="API" image="NSStatusUnavailable" enabled="NO" id="Gzh-BA-qbg">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                         </items>
                     </menu>

--- a/syncthing/DaemonProcess.swift
+++ b/syncthing/DaemonProcess.swift
@@ -1,0 +1,131 @@
+//
+//  DaemonProcess.swift
+//  syncthing
+//
+//  Created by Jakob Borg on 2018-07-29.
+//  Copyright © 2018 The syncthing-macos Authors. All rights reserved.
+//
+
+import Foundation
+
+let RestartInterval = 10.0 // seconds
+let MaxKeepLogLines = 200
+
+@objc public protocol DaemonProcessDelegate: class {
+    func process(_: DaemonProcess, isRunning: Bool)
+}
+
+@objc public class DaemonProcess: NSObject {
+    private var path: String
+    private weak var delegate: DaemonProcessDelegate?
+    private var process: Process?
+    private var log = [String]()
+    private var queue = DispatchQueue(label: "DaemonProcess")
+    private var shouldTerminate = false
+
+    init(path: String, delegate: DaemonProcessDelegate) {
+        self.path = path
+        self.delegate = delegate
+    }
+
+    func launch() {
+        queue.async {
+            self.launchSync()
+        }
+    }
+
+    func terminate() {
+        queue.async {
+            self.shouldTerminate = true
+            self.process?.terminate()
+        }
+    }
+
+    func restart() {
+        queue.async {
+            // Syncthing should exit cleanly when sent the interrupt signal. It will then be restarted.
+            self.process?.interrupt()
+        }
+    }
+
+    private func launchSync() {
+        NSLog("Launching Syncthing daemon")
+        shouldTerminate = false
+
+        let p = Process()
+        p.arguments = ["-no-browser", "-no-restart"]
+        p.launchPath = path
+        p.standardInput = Pipe() // isolate daemon from our stdin
+        p.standardOutput = pipeIntoLineBuffer()
+        p.standardError = pipeIntoLineBuffer()
+        p.terminationHandler = { p in self.queue.async { self.didTerminate(p) } }
+        p.qualityOfService = QualityOfService.background
+        p.launch()
+
+        DispatchQueue.main.async {
+            self.delegate?.process(self, isRunning: true)
+        }
+
+        process = p
+    }
+
+    private func didTerminate(_ p: Process) {
+        NSLog("Syncthing daemon terminated (exit code %d)", p.terminationStatus)
+        process = nil
+
+        DispatchQueue.main.async {
+            self.delegate?.process(self, isRunning: false)
+        }
+
+        if shouldTerminate {
+            return
+        }
+        var delay = 0.0
+        switch p.terminationStatus {
+        case 0:
+            // Successfull exit, such as when told to stop. We ignore
+            // that fact and restart anyway, with no delay. TODO(jb):
+            // Consider instead offering a "restart daemon" command in
+            // the menu?
+            break
+        case 3:
+            // Restarting. No delay necessary.
+            break
+        default:
+            // Anything else is an error condition of some kind. Delay
+            // the startup to not get caught in a tight loop.
+            delay = RestartInterval
+            NSLog("Delaying daemon startup by %.1f s", delay)
+        }
+        queue.asyncAfter(deadline: DispatchTime.now() + delay) {
+            self.launchSync()
+        }
+    }
+
+    private func pipeIntoLineBuffer() -> Pipe {
+        let p = Pipe()
+        p.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.count == 0 {
+                // No data available means EOF; we must unregister ourselves
+                // in order to not immediately be called again.
+                handle.readabilityHandler = nil
+                return
+            }
+
+            guard let str = String(data: data, encoding: .utf8) else {
+                // Non-UTF-8 data from Syncthing should never happen.
+                return
+            }
+
+            print(str, terminator: "")
+            self.queue.async {
+                self.log.append(contentsOf: str.components(separatedBy: "\n"))
+                if self.log.count > MaxKeepLogLines {
+                    self.log.removeFirst(self.log.count - MaxKeepLogLines)
+                }
+            }
+        }
+        return p
+    }
+}

--- a/syncthing/STApplication.h
+++ b/syncthing/STApplication.h
@@ -12,8 +12,9 @@
 #import "STStatusMonitor.h"
 #import "Controllers/STAboutWindowController.h"
 #import "Controllers/STPreferencesWindowController.h"
+#import "Syncthing-Swift.h"
 
-@interface STAppDelegate : NSObject <NSApplicationDelegate, STStatusMonitorDelegate>
+@interface STAppDelegate : NSObject <NSApplicationDelegate, STStatusMonitorDelegate, DaemonProcessDelegate>
 
 @property (weak) IBOutlet NSMenu *Menu;
 @property (nonatomic, readonly) NSStatusItem *statusItem;

--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -280,13 +280,13 @@
     }
     _daemonOK = isRunning;
     if (_daemonOK) {
-        [_daemonStatusMenuItem setTitle:@"Daemon (running)"];
+        [_daemonStatusMenuItem setTitle:@"Background Service (Running)"];
         [_daemonStatusMenuItem setImage:[NSImage imageNamed:@"NSStatusAvailable"]];
         [_daemonStartMenuItem setEnabled:NO];
         [_daemonStopMenuItem setEnabled:YES];
         [_daemonRestartMenuItem setEnabled:YES];
     } else {
-        [_daemonStatusMenuItem setTitle:@"Daemon (stopped)"];
+        [_daemonStatusMenuItem setTitle:@"Background Service (Stopped)"];
         [_daemonStatusMenuItem setImage:[NSImage imageNamed:@"NSStatusUnavailable"]];
         [_daemonStartMenuItem setEnabled:YES];
         [_daemonStopMenuItem setEnabled:NO];
@@ -302,10 +302,10 @@
     }
     _connectionOK = isConnected;
     if (_connectionOK) {
-        [_connectionStatusMenuItem setTitle:@"Connection (online)"];
+        [_connectionStatusMenuItem setTitle:@"API (Online)"];
         [_connectionStatusMenuItem setImage:[NSImage imageNamed:@"NSStatusAvailable"]];
     } else {
-        [_connectionStatusMenuItem setTitle:@"Connection (disconnected)"];
+        [_connectionStatusMenuItem setTitle:@"API (Offline)"];
         [_connectionStatusMenuItem setImage:[NSImage imageNamed:@"NSStatusUnavailable"]];
     }
     
@@ -313,23 +313,22 @@
 }
 
 - (void)updateAggregateState {
-    int ok = 0;
     if (_daemonOK) {
-        ok++;
-    }
-    if (_connectionOK) {
-        ok++;
-    }
-    switch (ok) {
-        case 0:
-            [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusUnavailable"]];
-            break;
-        case 1:
-            [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusPartiallyAvailable"]];
-            break;
-        case 2:
+        if (_connectionOK) {
             [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusAvailable"]];
-            break;
+            [_statusMenuItem setTitle:@"Online"];
+        } else {
+            [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusPartiallyAvailable"]];
+            [_statusMenuItem setTitle:@"Running (Offline)"];
+        }
+    } else {
+        if (_connectionOK) {
+            [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusPartiallyAvailable"]];
+            [_statusMenuItem setTitle:@"Unknown (Online)"];
+        } else {
+            [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusUnavailable"]];
+            [_statusMenuItem setTitle:@"Unavailable"];
+        }
     }
 }
 

--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -38,10 +38,6 @@
     _statusMonitor.syncthing = _syncthing;
     _statusMonitor.delegate = self;
     [_statusMonitor startMonitoring];
-    
-    [_statusMenuItem setImage:[NSImage imageNamed:@"NSStatusNone"]];
-    [_connectionStatusMenuItem setImage:[NSImage imageNamed:@"NSStatusNone"]];
-    [_daemonStatusMenuItem setImage:[NSImage imageNamed:@"NSStatusNone"]];
 }
 
 - (void) clickedFolder:(id)sender {
@@ -212,7 +208,6 @@
 }
 
 - (IBAction) clickedQuit:(id)sender {
-    [_syncthing stopExecutable];
     [_statusMonitor stopMonitoring];
     
     [self updateStatusIcon:@"StatusIconNotify"];

--- a/syncthing/XGSyncthing.h
+++ b/syncthing/XGSyncthing.h
@@ -5,7 +5,6 @@
 
 @interface XGSyncthing : NSObject<NSXMLParserDelegate>
 
-@property (nonatomic, copy) NSString *Executable;
 @property (nonatomic, copy) NSString *URI;
 @property (nonatomic, copy) NSString *ApiKey;
 

--- a/syncthing/XGSyncthing.h
+++ b/syncthing/XGSyncthing.h
@@ -9,16 +9,6 @@
 @property (nonatomic, copy) NSString *URI;
 @property (nonatomic, copy) NSString *ApiKey;
 
-/**
- * Run the syncthing executable
- * E.g from Syncthing.app/MacOS/Resources/syncthing/syncthing: 
- *  "[NSString stringWithFormat:@"%@/%@",[[NSBundle mainBundle] resourcePath], @"syncthing/syncthing"]"
- */
-- (bool)runExecutable;
-// Interrupts syncthing and block-waits until exit
-- (void)stopExecutable;
-
-
 - (bool)ping;
 - (id)getUptime;
 - (id)getMyID;

--- a/syncthing/XGSyncthing.m
+++ b/syncthing/XGSyncthing.m
@@ -14,7 +14,6 @@
 
 @implementation XGSyncthing {}
 
-@synthesize Executable = _Executable;
 @synthesize URI = _URI;
 @synthesize ApiKey = _apiKey;
 

--- a/syncthing/XGSyncthing.m
+++ b/syncthing/XGSyncthing.m
@@ -6,7 +6,6 @@
 
 @interface XGSyncthing()
 
-@property NSTask *StTask;
 @property (nonatomic, strong) NSXMLParser *configParser;
 @property (nonatomic, strong) NSMutableArray<NSString *> *parsing;
 @property (nonatomic, strong) NSURLSession *session;
@@ -18,27 +17,6 @@
 @synthesize Executable = _Executable;
 @synthesize URI = _URI;
 @synthesize ApiKey = _apiKey;
-
-- (bool) runExecutable
-{
-    _StTask = [[NSTask alloc] init];
-
-    [_StTask setLaunchPath:_Executable];
-    [_StTask setArguments:@[@"-no-browser"]];
-    [_StTask setQualityOfService:NSQualityOfServiceBackground];
-    [_StTask launch];
-
-    return true;
-}
-
-- (void) stopExecutable
-{
-    if (!_StTask)
-        return;
-
-    [_StTask interrupt];
-    [_StTask waitUntilExit];
-}
 
 - (id)sendRequestToEndpoint:(NSString *)endpoint method:(NSString *)method parameters:(NSDictionary *)parameters
 {

--- a/syncthing/syncthing-Bridging-Header.h
+++ b/syncthing/syncthing-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+


### PR DESCRIPTION
UI wise it adds a status item that is split into connection status and process status. It's possible and valid for the process to be down and the connection to be up - if the process is running but not controlled by us, or we're talking to a remote host. Depending on the process state there are start/stop/restart actions available.

All good:

<img width="491" alt="screen shot 2018-07-30 at 11 32 02" src="https://user-images.githubusercontent.com/125426/43389773-cff6743c-93ec-11e8-8e4d-c003fb0e1819.png">

Process down, connection up:

<img width="491" alt="screen shot 2018-07-30 at 11 32 27" src="https://user-images.githubusercontent.com/125426/43389780-d1c6fc0a-93ec-11e8-81ee-97c6869b4741.png">

Fail:

<img width="401" alt="screen shot 2018-07-30 at 11 32 42" src="https://user-images.githubusercontent.com/125426/43389795-dd9705de-93ec-11e8-87fc-7f952211e985.png">

Remaining points and questions:

- We probably need a preferences flag for not attempting to start/manage the process at all, for cases where the user is not talking to localhost. However this isn't possible today, so maybe future enhancement?

- UI wise, how do we want to talk about this. I say "daemon" above because that's technically correct, but will sound occult and/or meaningless to most presumptive users, probably. What should we call it?

- Likewise, "connection". It's clear to me that this is towards the Syncthing daemon, but a regular user might not see the two things as separate at all... Maybe this whole PR is misdirected. :/

- Cleanup remains, so far I've just added stuff and not removed the previous process monitoring / moved the "Executable" config, etc.