### PR TITLE
Copy executable from bundle (fixes #37)

### DIFF
--- a/syncthing/UI/STPreferencesWindow/STPreferencesAdvancedViewController.m
+++ b/syncthing/UI/STPreferencesWindow/STPreferencesAdvancedViewController.m
@@ -20,6 +20,7 @@
 
 - (id) init {
     self = [super initWithNibName:NSStringFromClass(self.class) bundle:nil];
+    // TODO(jb): Executable placement shown should be taken from config.
     return self;
 }
 

--- a/syncthing/UI/STPreferencesWindow/STPreferencesAdvancedViewController.xib
+++ b/syncthing/UI/STPreferencesWindow/STPreferencesAdvancedViewController.xib
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="STPreferencesAdvancedViewController">
@@ -36,27 +38,16 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zWx-is-mDL">
-                    <rect key="frame" x="164" y="88" width="217" height="17"/>
+                    <rect key="frame" x="30" y="63" width="372" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="/Applications/Syncthing.app/Contents/Resources/syncthing/syncthing" usesSingleLineMode="YES" id="rs8-Wp-ExC">
+                    <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="~/Library/Application Support/Syncthing-macOS/syncthing" usesSingleLineMode="YES" id="rs8-Wp-ExC">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="axM-vn-auF">
-                    <rect key="frame" x="387" y="86" width="13" height="19"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSActionTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="OdM-cl-4yY">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                </button>
             </subviews>
             <point key="canvasLocation" x="109" y="95.5"/>
         </customView>
     </objects>
-    <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
-    </resources>
 </document>


### PR DESCRIPTION
This copies the bundled executable before executing it, if the target
executable doesn't already exist. This has several desirable properties:

- We do not mess up the application bundle by letting Syncthing upgrade

- The user can revert an undesired upgrade by deleting the binary and
  restarting the wrapper.

The binary is stored in ~/Application Support/Syncthing-macOS because I
don't want to put it in Syncthing's config directory. That directory is
in principle managed by Syncthing and we can't be sure it won't be
removed or something.