### PR TITLE
fixed homebrew typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ provisioning an remote syncthing instance, the local instance is auto-configured
 
 The latest version can be downloaded from [Github Releases](https://github.com/syncthing/syncthing-macos/releases/latest)
 
-Or [homebrew](https://github.com/Homebrew/homebrew-cask) can be used: `brew cask install syncthing-app`
+Or [homebrew](https://github.com/Homebrew/homebrew-cask) can be used: `brew cask install syncthing`
 
 # Why
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently, OS X 10.10 or higher is necessary. **syncthing-macos** is packaged as
 
 To install just download the dmg, mount it and drag and drop the application to install. The only necessary configuration is to set the API key and URL when provisioning a remote syncthing instance, the local instance is auto-configured. The application automatically keeps the syncthing binary updated, while running.
 
-The latest version is available at [Github Releases](https://github.com/syncthing/syncthing-macos/releases/latest), or it can also be install using [homebrew](https://github.com/Homebrew/homebrew-cask) `brew cask install syncthing`
+The latest version is available at [Github Releases](https://github.com/syncthing/syncthing-macos/releases/latest), or it can also be installed using [homebrew](https://github.com/Homebrew/homebrew-cask) `brew cask install syncthing`
 
 # Why
 


### PR DESCRIPTION
Fixed homebrew cask command since it has been renamed to remove "app" suffix per issue https://github.com/Homebrew/homebrew-cask/commit/f2990ac0379ef538627e598f20644d73557a06fe