### PR TITLE
Don't reuse app icon for disk image

### DIFF
--- a/syncthing/Scripts/create-dmg.sh
+++ b/syncthing/Scripts/create-dmg.sh
@@ -47,7 +47,6 @@ else
 	${CREATE_DMG} \
 		--sandbox-safe \
 		--volname "Syncthing" \
-		--volicon "${SYNCTHING_APP_RESOURCES}/syncthing.icns" \
 		--background "${DMG_TEMPLATE_DIR}/background.png" \
 		--window-pos -1 -1 \
 		--window-size 480 540 \


### PR DESCRIPTION
This pull request removes the `--volicon` flag from the create-dmg script.

Currently Syncthing reuses the app icon for its disk image. While custom icons for DMGs are a nice touch, reusing the app icon is confusing in my opinion.

Consider this screenshot of three disk images an my desktop from apps I downloaded:
<img width="370" alt="Bildschirmfoto 2021-11-23 um 23 11 07" src="https://user-images.githubusercontent.com/198305/143137208-107df101-a221-4851-b83a-bded0ccbe63d.png">
 
While for Firefox and for Sketch it's immediately clear that these are disk images, the center icon looks like it's the app itself! So I tried dragging it to my Applications folder, which obviously doesn't work since it's a disk image!

So I think it's better to use no custom icon for the disk image to make it clear that this is a disk image, not the app itself.