### PR TITLE
Fix DaemonProcess launch uncaught exception when the executable path is invalid/non-executable

### DIFF
--- a/syncthing/DaemonProcess.swift
+++ b/syncthing/DaemonProcess.swift
@@ -55,7 +55,7 @@ let MaxKeepLogLines = 200
     }
 
     private func launchSync() {
-        NSLog("Launching Syncthing daemon")
+        NSLog("Launching Syncthing daemon: \(path)")
         shouldTerminate = false
 
         // Since release v1.7.0-1 we don't allow Syncthing daemon to update by itself

--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -72,6 +72,9 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
     _executable = self.arguments = [defaults stringForKey:@"Executable"];
+
+    // Check that the excutable is valid (not null, exists and is executable)
+    // If it's not, nullify it so that it will be set to the default value
     if (_executable) {
         NSFileManager *fileManager = [NSFileManager defaultManager];
         if (![fileManager fileExistsAtPath:_executable]) {

--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -85,11 +85,12 @@
             _executable = nil;
         }
     }
-	if (!_executable) {
-	    _executable = [NSString stringWithFormat:@"%@/%@",
+
+    if (!_executable) {
+        _executable = [NSString stringWithFormat:@"%@/%@",
                        [[NSBundle mainBundle] resourcePath],
                        @"syncthing/syncthing"];
-	}
+    }
 
     _syncthing.URI = [defaults stringForKey:@"URI"];
     _syncthing.ApiKey = [defaults stringForKey:@"ApiKey"];

--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -72,6 +72,16 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
     _executable = self.arguments = [defaults stringForKey:@"Executable"];
+    if (_executable) {
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        if (![fileManager fileExistsAtPath:_executable]) {
+            NSLog(@"Resetting Syncthing daemon path because it does not exist: (%@)", _executable);
+            _executable = nil;
+        } else if (![fileManager isExecutableFileAtPath:_executable]) {
+            NSLog(@"Resetting Syncthing daemon path because is not executable: (%@)", _executable);
+            _executable = nil;
+        }
+    }
 	if (!_executable) {
 	    _executable = [NSString stringWithFormat:@"%@/%@",
                        [[NSBundle mainBundle] resourcePath],

--- a/syncthing/STApplication.m
+++ b/syncthing/STApplication.m
@@ -75,10 +75,10 @@
     if (_executable) {
         NSFileManager *fileManager = [NSFileManager defaultManager];
         if (![fileManager fileExistsAtPath:_executable]) {
-            NSLog(@"Resetting Syncthing daemon path because it does not exist: (%@)", _executable);
+            NSLog(@"Resetting Syncthing daemon executable path because it doesn't exist: (%@)", _executable);
             _executable = nil;
         } else if (![fileManager isExecutableFileAtPath:_executable]) {
-            NSLog(@"Resetting Syncthing daemon path because is not executable: (%@)", _executable);
+            NSLog(@"Resetting Syncthing daemon executable path because it's non-executable: (%@)", _executable);
             _executable = nil;
         }
     }


### PR DESCRIPTION
I've fixed the bug before reading the _Contributing Guidelines_, so if any changes must be made do not hesitate to tell me. Given that this _Pull Request_ is to fix a bug I've run into, I will describe it as if I were opening an _Issue_ (if you need me to create an actual _Issue_ I can do so as well). Also, because I am unexperienced regarding the macOS ecosystem, I will not upload the crash report because I don't know which segments might contain private information (if they are needed, which is unlikely due to the simplicity of the bug, I can share them privately).

## What happened

- I expected the Syncthing GUI app to start, the tray icon to appear, and the daemon to be launched.
- The tray icon did not show up or it did briefly and disappeared quickly; the daemon was not running in any case.

## What operating system, operating system version and version of Syncthing you are running

- Model: MacBook Air 2022
- Chip: Apple M2
- OS: macOS Sequoia 15.3.1 (24D70)
- Syncthing: 1.29.2-1 (102900201)

## The same for other connected devices, where relevant

- Not relevant.

## Screenshot if the issue concerns something visible in the GUI

- Not relevant.

## Console log entries, where possible and relevant

- Not shared due to privacy concerns (and ignorance about the personal information it has).