### PR TITLE
update DaemonProcess.swift for 2.0

### DIFF
--- a/syncthing/DaemonProcess.swift
+++ b/syncthing/DaemonProcess.swift
@@ -64,7 +64,7 @@ let MaxKeepLogLines = 200
 
         let p = Process()
         p.environment = environment
-        p.arguments = ["-no-browser", "-no-restart", "-logfile=default"]
+        p.arguments = ["--no-browser", "--no-restart", "--logfile=default"]
         p.arguments?.append(contentsOf: self.arguments)
         p.launchPath = path
         p.standardInput = Pipe() // isolate daemon from our stdin


### PR DESCRIPTION
## Required change for the upcoming 2.0 release

In accordance with [the release notes of 2.0-rc.16](https://github.com/syncthing/syncthing/releases/tag/v2.0.0-rc.16) single-dash commandline options are no longer supported.

(without this, the `syncthing` process fails to start)
